### PR TITLE
ci(mirror) Add Epitech repository mirroring workflow

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,20 @@
+name: 'Mirroring workflow'
+on:
+  push:
+    branches:
+      - 'main'
+env:
+  MIRROR_URL: 'git@github.com:EpitechPromo2027/B-CCP-400-REN-4-1-panoramix-thibaut.hebert-henriette.git'
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            ${{ env.MIRROR_URL }}
+          ssh_private_key:
+            ${{ secrets.SSH_MIRROR_KEY }}


### PR DESCRIPTION
## Additions

- Github Action for Epitech project delivery

## Issues

Resolves #1.