### PR TITLE
ci(dependabot) Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - "ThibautHH"
+    reviewers:
+      - "ThibautHH"
+    commit-message:
+      prefix: "ci(deps) "
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "dependencies/github-actions"


### PR DESCRIPTION
## Additions

- Dependabot configuration for GitHub Actions

## Issues

Resolves #2.
